### PR TITLE
feat(get_class_details): continue processing remaining classes when a 404 is encountered

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: ucla-timetable
-version: 1.0.0
+version: 1.0.1
 
 development_dependencies:
   webmock:

--- a/src/ucla-timetable/requests.cr
+++ b/src/ucla-timetable/requests.cr
@@ -38,8 +38,10 @@ class UCLA::Timetable
     subject_area_code : String,
     course_catalog_number : String,
     class_number : String,
-  ) : ClassDetails
+  ) : ClassDetails?
     request(NamedTuple(classDetail: ClassDetails), "/sis/classes/#{offered_term_code}/#{subject_area_code}/#{course_catalog_number}/#{class_number}/classdetail/v1")[:classDetail]
+  rescue
+    nil
   end
 
   def get_class_section(


### PR DESCRIPTION
When testing the driver that uses this lib for the first time e2e, there is a scenario where a Class (in the context of university teaching class, schedule, term, etc... not OOP) exists (because it's id is returned by the same API in a "list all classes in a term" response), BUT the Get Class details request for that class id gets a 404 from the API (facepalm).

In that scenario the driver's goal was to process all the classes that term (hundreds of them), but when the above 404 is encountered, it stops processing the remaining classes in the term and errors.

The goal in this PR is to essentially ignore the 404, skip attempting to process the class that 404ed, and continue processing the remaining classes in the term.

More info:
When e2e testing,The driver using it is executing this section: https://github.com/place-labs/nda-drivers/blob/60765fbda9c3af8d6945659de188896a93f720dd/drivers/ucla/timetable.cr#L55-L59
and then fails midway through the sequential batch processing with
```
[PlaceOS][WS] [DEBUG] mod-I~pvSUPxDD → error caching events
HTTP error requesting: GET https://<redacted>/sis/classes/<redacted>/a%26o%20sci/0213/001/classdetail/v1
404 - No Records Found (Exception)
  from /usr/share/crystal/src/json/serialization.cr:182:7 in 'calendar_events'
  from /tmp/20250812-1-adfmqedrivers_ucla_timetable/drivers/ucla/timetable.cr:57:7 in 'fetch_timetable'
```
And does not attempt to continue processing the rest of the batch.